### PR TITLE
Fix markdown mimetype role issues

### DIFF
--- a/ansible/roles/markdown_mimetype/tasks/main.yml
+++ b/ansible/roles/markdown_mimetype/tasks/main.yml
@@ -13,6 +13,7 @@
     state: directory
     recurse: true
     mode: '0775'
+  changed_when: false
 - name: Create new markdown mimetype file
   become: false
   copy:
@@ -20,10 +21,12 @@
     dest: ~/.local/share/mime/packages/text-markdown.xml
     mode: '0664'
     force: true
+  changed_when: false
 - name: Insert content into mimetype file
   become: false
   copy:
     content: '{{ mime_content }}'
     dest: ~/.local/share/mime/packages/text-markdown.xml
     mode: '0664'
+  changed_when: false
   notify: Update mime database

--- a/ansible/roles/markdown_mimetype/tasks/main.yml
+++ b/ansible/roles/markdown_mimetype/tasks/main.yml
@@ -1,18 +1,29 @@
 ---
+# NOTE: We need `become: false` here, otherwise the files would be installed
+# for the root user.
 - name: Ensure shared-mime-info is installed
+  become: false
   apt:
     pkg:
       - shared-mime-info
 - name: Prepare markdown mimetype directory
+  become: false
   file:
     path: ~/.local/share/mime/packages/
     state: directory
     recurse: true
+    mode: '0775'
 - name: Create new markdown mimetype file
+  become: false
   copy:
     content: ""
     dest: ~/.local/share/mime/packages/text-markdown.xml
-    force: false
+    mode: '0664'
+    force: true
 - name: Insert content into mimetype file
-  copy: content={{ mime_content }} dest=~/.local/share/mime/packages/text-markdown.xml
+  become: false
+  copy:
+    content: '{{ mime_content }}'
+    dest: ~/.local/share/mime/packages/text-markdown.xml
+    mode: '0664'
   notify: Update mime database


### PR DESCRIPTION
* Not using `become: true` anymore
* Specify permissions for `copy` tasks
