### PR TITLE
dependabot/pip/ansible 2.10.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
             source .venv/bin/activate && ./test/vim && ./test/yaml && ./test/shellcheck"
 
   full-setup-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Install

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -3,7 +3,7 @@ extends: default
 
 
 ignore: |
-  ansible/roles/angstwad.docker_ubuntu/
+  ansible/roles/geerlingguy.docker/
   ansible/roles/FGtatsuro.python-requirements/
   ansible/roles/FGtatsuro.virtualbox/
   ansible/roles/FGtatsuro.vagrant/

--- a/ansible/playbooks/additional_packages.yml
+++ b/ansible/playbooks/additional_packages.yml
@@ -12,6 +12,7 @@
     - role: markdown_mimetype
     # - role: FGtatsuro.vagrant
     - role: geerlingguy.docker
+      when: lookup('env', 'CI') == 'false'
   tasks:
     - name: Install additional apt packages
       apt:

--- a/ansible/playbooks/additional_packages.yml
+++ b/ansible/playbooks/additional_packages.yml
@@ -11,7 +11,7 @@
           - "--git https://github.com/greshake/i3status-rust i3status-rs"
     - role: markdown_mimetype
     # - role: FGtatsuro.vagrant
-    - role: angstwad.docker_ubuntu
+    - role: geerlingguy.docker
   tasks:
     - name: Install additional apt packages
       apt:

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,5 +1,5 @@
 ---
-- src: angstwad.docker_ubuntu
+- src: geerlingguy.docker
 - src: FGtatsuro.vagrant
 # - src: ferrarimarco.ruby-install
 # - src: ferrarimarco.chruby

--- a/ansible/roles/github_cli/tasks/main.yml
+++ b/ansible/roles/github_cli/tasks/main.yml
@@ -27,7 +27,6 @@
   get_url:
     url: "{{ download_url.stdout }}"
     dest: /tmp/gh_cli.deb
-    remote_src: true
   changed_when: false
 - name: Install latest release
   apt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 molecule==2.20.1
-ansible==2.9.20
+ansible==2.10.6
 docker==5.0.0
 jmespath==0.10.0
 vim-vint==0.3.21

--- a/setup
+++ b/setup
@@ -56,7 +56,7 @@ bootstrap()
   pip3 uninstall -y testinfra
   pip3 install testinfra
 
-  install_mitogen '0.2.9'
+  install_mitogen '0.3.0rc1'
   # Not exactly sure who I have to reload the env here.. Otherwise
   # `ansible-galaxy` fails immediately with an invalid interpreter error.
   # shellcheck disable=SC1091
@@ -64,7 +64,7 @@ bootstrap()
 
   ansible-galaxy install -r ansible/requirements.yml --force
 
-  install_mitogen '0.2.9'
+  install_mitogen '0.3.0rc1'
 
   default_playbooks=(
     ansible/playbooks/base.yml


### PR DESCRIPTION
- Bump ansible from 2.9.6 to 2.10.6
- Remove incorrect 'remote_src'
- Try installing mitogen release candidate
- Switch to geerlingguy.docker package
- Use Ubuntu 20.04 for full-setup-test
