### PR TITLE
i3: Hide bar by default

### DIFF
--- a/i3wm/.config/i3/config
+++ b/i3wm/.config/i3/config
@@ -212,6 +212,7 @@ bar {
   status_command ~/.cargo/bin/i3status-rs ~/.config/i3status-rust/config.toml
   position bottom
   modifier $mod
+  mode hide
   tray_output primary
 
   colors {


### PR DESCRIPTION
I found it to be a source of distraction sometimes, so it's hidden for
now.
